### PR TITLE
major cleanup

### DIFF
--- a/.github/workflows/check-for-updates.yml
+++ b/.github/workflows/check-for-updates.yml
@@ -9,8 +9,6 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v2
-
       - name: auth 1
         id: token
         run: curl -sL "https://v2.onivim.io/auth/licenseKey?licenseKey=${ONIVIM_TOKEN}" -o /tmp/key.json

--- a/.github/workflows/check-pr.yml
+++ b/.github/workflows/check-pr.yml
@@ -1,0 +1,16 @@
+name: Test Install
+
+on:
+  pull_request:
+    branches: [ master ]
+
+jobs:
+  test:
+    runs-on: macos-latest
+    strategy:
+      matrix:
+        package: [onivim2, onivim2-nightly]
+    steps:
+      - uses: actions/checkout@v2
+      - name: style
+        run: brew style --cask Casks/${{ matrix.package }}.rb

--- a/.github/workflows/test-install.yml
+++ b/.github/workflows/test-install.yml
@@ -3,8 +3,6 @@ name: Test Install
 on:
   push:
     branches: [ master ]
-  pull_request:
-    branches: [ master ]
   schedule:
     - cron: 30 0 * * *
 
@@ -15,11 +13,11 @@ jobs:
       matrix:
         package: [onivim2, onivim2-nightly]
     steps:
-    - name: Tap Repo
-      run: brew tap --quiet marblenix/homebrew-onivim2
-      env:
-        HOMEBREW_ONIVIM_SERIAL: ${{ secrets.ONIVIM_TOKEN }}
-    - name: Install OniVim2
-      run: brew install --quiet ${{ matrix.package }}
-      env:
-        HOMEBREW_ONIVIM_SERIAL: ${{ secrets.ONIVIM_TOKEN }}
+      - name: Tap Repo
+        run: brew tap --quiet marblenix/homebrew-onivim2
+        env:
+          HOMEBREW_ONIVIM_SERIAL: ${{ secrets.ONIVIM_TOKEN }}
+      - name: Install OniVim2
+        run: brew install --quiet ${{ matrix.package }}
+        env:
+          HOMEBREW_ONIVIM_SERIAL: ${{ secrets.ONIVIM_TOKEN }}

--- a/Casks/onivim2-nightly.rb
+++ b/Casks/onivim2-nightly.rb
@@ -1,48 +1,97 @@
-# frozen_string_literal: true
+# Defined in the website js
+FIREBASE_API_KEY = "AIzaSyDxflsfyd2gloxgWJ-GFtPM46tz-TtOXh8".freeze
+ONIVIM_BASE_URL = "https://v2.onivim.io".freeze
+LICENSE_KEY_ENV = "HOMEBREW_ONIVIM_SERIAL".freeze
+ZAP_LIST = [
+  "~/.config/oni2",
+  "~/Library/Preferences/com.outrunlabs.onivim2.plist",
+  "~/Library/Saved Application State/com.outrunlabs.onivim2.savedState",
+].freeze
 
-require 'open-uri'
-require 'net/http'
-require 'json'
-
-class InvalidLicenseError < StandardError
-end
-
-# Custom Download strategy to fix @cached_location name length limitation
+# Custom Download strategy to bypass @cached_location name length limitation
 class OniVimDownloadStrategy < CurlDownloadStrategy
+  # noinspection RubyArgCount
   def initialize(url, name, version, **meta)
     super
-    @cached_location = Pathname.new("#{HOMEBREW_CACHE}/downloads/OniVim2-nightly.app")
+    @cached_location = Pathname.new("#{HOMEBREW_CACHE}/downloads/OniVim2-#{version}.app")
     @symlink_location = Pathname.new("#{@cache}/#{name}.app")
     @temporary_path = Pathname.new("#{@cached_location}.incomplete")
   end
 end
 
-# Defined in the website js
-FIREBASE_API_KEY = 'AIzaSyDxflsfyd2gloxgWJ-GFtPM46tz-TtOXh8'
+class NoLicenseFoundError < StandardError
+  def initialize(msg = nil)
+    super msg || "No license was found"
+  end
+end
 
-cask 'onivim2-nightly' do
-  app 'OniVim2.app'
-  name 'OniVim2-nightly'
-  version :latest
-  sha256 :no_check
-  conflicts_with cask: 'onivim2'
-  homepage 'https://v2.onivim.io/'
+class InvalidLicenseError < StandardError
+  def initialize(msg = nil)
+    super msg || "License key is invalid"
+  end
+end
 
-  # Verify license key
-  serial_key = ENV.fetch('HOMEBREW_ONIVIM_SERIAL')
-  is_valid_response = URI("https://v2.onivim.io/api/isLicenseKeyValid?licenseKey=#{serial_key}").open.read
-  is_valid = JSON.parse(is_valid_response)
-  raise InvalidLicenseError unless is_valid.to_s == 'true'
+# Handle authentication for downloading OniVim2
+class AuthenticationProvider
+  # @raise NoLicenseFoundError if no license key is found
+  def initialize(serial_key: nil)
+    @serial_key = serial_key || ENV.fetch(LICENSE_KEY_ENV, nil)
+    raise NoLicenseFoundError if @serial_key.nil?
+  end
 
-  # Get a temporary download token
-  token_response = URI("https://v2.onivim.io/auth/licenseKey?licenseKey=#{serial_key}").open.read
-  token = JSON.parse(token_response)['token']
-  custom_token_url = URI.parse('https://www.googleapis.com/identitytoolkit/v3/relyingparty/verifyCustomToken' \
+  # @return true if the license key is valid
+  def valid_serial
+    response = URI("#{ONIVIM_BASE_URL}/api/isLicenseKeyValid?licenseKey=#{@serial_key}").open.read
+    JSON.parse(response).to_s == "true"
+  end
+
+  # @return a token to allow downloading the OniVim2 binary
+  # @raise InvalidLicenseError
+  def download_token
+    require "open-uri"
+    require "net/http"
+    require "json"
+
+    # Verify license key
+    raise InvalidLicenseError unless valid_serial
+
+    # Get a temporary download token
+    token_response = URI("#{ONIVIM_BASE_URL}/auth/licenseKey?licenseKey=#{@serial_key}").open.read
+    token = JSON.parse(token_response)["token"]
+    custom_token_url = URI.parse("https://www.googleapis.com/identitytoolkit/v3/relyingparty/verifyCustomToken" \
                                    "?key=#{FIREBASE_API_KEY}")
 
-  params = {'returnSecureToken' => 'true', 'token' => token}
-  custom_token_response = Net::HTTP.post_form(custom_token_url, params)
-  id_token = JSON.parse(custom_token_response.body)['idToken']
+    custom_token_response = Net::HTTP.post_form(custom_token_url, { "returnSecureToken" => "true", "token" => token })
+    JSON.parse(custom_token_response.body)["idToken"]
+  end
+end
 
-  url "https://v2.onivim.io/downloads/Onivim2.dmg?channel=master&token=#{id_token}", using: OniVimDownloadStrategy
+cask "onivim2-nightly" do
+  version :latest
+  sha256 :no_check
+
+  url do
+    [
+      "#{ONIVIM_BASE_URL}/downloads/Onivim2.dmg?channel=master&token=#{AuthenticationProvider.new.download_token}",
+      { using: OniVimDownloadStrategy, referer: "https://github.com/marblenix/homebrew-onivim2" },
+    ]
+  end
+  name "OniVim2-nightly"
+  desc "Native, lightweight modal code editor"
+  homepage ONIVIM_BASE_URL.to_s
+
+  conflicts_with cask: "onivim2"
+
+  app "OniVim2.app"
+  shim_script = "#{staged_path}/oni2.wrapper.sh"
+  binary shim_script, target: "oni2"
+
+  preflight do
+    IO.write shim_script, <<~EOS
+      #!/bin/sh
+      exec "#{appdir}/OniVim2.app/Contents/MacOS/Oni2" "$@"
+    EOS
+  end
+
+  zap trash: ZAP_LIST
 end

--- a/Casks/onivim2.rb
+++ b/Casks/onivim2.rb
@@ -1,48 +1,100 @@
-# frozen_string_literal: true
+VERSION = "0.5.3".freeze
+SHA_256 = "8caa44ace2b0ea2c0dcf2165cb44b1485f0d2147a297edc7d3bae2f21741eca7".freeze
 
-require 'open-uri'
-require 'net/http'
-require 'json'
+# Defined in the website js
+FIREBASE_API_KEY = "AIzaSyDxflsfyd2gloxgWJ-GFtPM46tz-TtOXh8".freeze
+ONIVIM_BASE_URL = "https://v2.onivim.io".freeze
+LICENSE_KEY_ENV = "HOMEBREW_ONIVIM_SERIAL".freeze
+ZAP_LIST = [
+  "~/.config/oni2",
+  "~/Library/Preferences/com.outrunlabs.onivim2.plist",
+  "~/Library/Saved Application State/com.outrunlabs.onivim2.savedState",
+].freeze
 
-class InvalidLicenseError < StandardError
-end
-
-# Custom Download strategy to fix @cached_location name length limitation
+# Custom Download strategy to bypass @cached_location name length limitation
 class OniVimDownloadStrategy < CurlDownloadStrategy
+  # noinspection RubyArgCount
   def initialize(url, name, version, **meta)
     super
-    @cached_location = Pathname.new("#{HOMEBREW_CACHE}/downloads/OniVim2-stable.app")
+    @cached_location = Pathname.new("#{HOMEBREW_CACHE}/downloads/OniVim2-#{version}.app")
     @symlink_location = Pathname.new("#{@cache}/#{name}.app")
     @temporary_path = Pathname.new("#{@cached_location}.incomplete")
   end
 end
 
-# Defined in the website js
-FIREBASE_API_KEY = 'AIzaSyDxflsfyd2gloxgWJ-GFtPM46tz-TtOXh8'
+class NoLicenseFoundError < StandardError
+  def initialize(msg = nil)
+    super msg || "No license was found"
+  end
+end
 
-cask 'onivim2' do
-  app 'OniVim2.app'
-  name 'OniVim2'
-  version '0.5.4'
-  sha256 'e1725689c51d5636892f385e9de53b88005c0ed57c7b370c7f04c3f95d4961c3'
-  conflicts_with cask: 'onivim2-nightly'
-  homepage 'https://v2.onivim.io/'
+class InvalidLicenseError < StandardError
+  def initialize(msg = nil)
+    super msg || "License key is invalid"
+  end
+end
 
-  # Verify license key
-  serial_key = ENV.fetch('HOMEBREW_ONIVIM_SERIAL')
-  is_valid_response = URI("https://v2.onivim.io/api/isLicenseKeyValid?licenseKey=#{serial_key}").open.read
-  is_valid = JSON.parse(is_valid_response)
-  raise InvalidLicenseError unless is_valid.to_s == 'true'
+# Handle authentication for downloading OniVim2
+class AuthenticationProvider
+  # @raise NoLicenseFoundError if no license key is found
+  def initialize(serial_key: nil)
+    @serial_key = serial_key || ENV.fetch(LICENSE_KEY_ENV, nil)
+    raise NoLicenseFoundError if @serial_key.nil?
+  end
 
-  # Get a temporary download token
-  token_response = URI("https://v2.onivim.io/auth/licenseKey?licenseKey=#{serial_key}").open.read
-  token = JSON.parse(token_response)['token']
-  custom_token_url = URI.parse('https://www.googleapis.com/identitytoolkit/v3/relyingparty/verifyCustomToken' \
+  # @return true if the license key is valid
+  def valid_serial
+    response = URI("#{ONIVIM_BASE_URL}/api/isLicenseKeyValid?licenseKey=#{@serial_key}").open.read
+    JSON.parse(response).to_s == "true"
+  end
+
+  # @return a token to allow downloading the OniVim2 binary
+  # @raise InvalidLicenseError
+  def download_token
+    require "open-uri"
+    require "net/http"
+    require "json"
+
+    # Verify license key
+    raise InvalidLicenseError unless valid_serial
+
+    # Get a temporary download token
+    token_response = URI("#{ONIVIM_BASE_URL}/auth/licenseKey?licenseKey=#{@serial_key}").open.read
+    token = JSON.parse(token_response)["token"]
+    custom_token_url = URI.parse("https://www.googleapis.com/identitytoolkit/v3/relyingparty/verifyCustomToken" \
                                    "?key=#{FIREBASE_API_KEY}")
 
-  params = {'returnSecureToken' => 'true', 'token' => token}
-  custom_token_response = Net::HTTP.post_form(custom_token_url, params)
-  id_token = JSON.parse(custom_token_response.body)['idToken']
+    custom_token_response = Net::HTTP.post_form(custom_token_url, { "returnSecureToken" => "true", "token" => token })
+    JSON.parse(custom_token_response.body)["idToken"]
+  end
+end
 
-  url "https://v2.onivim.io/downloads/Onivim2.dmg?channel=stable&token=#{id_token}", using: OniVimDownloadStrategy
+cask "onivim2" do
+  version VERSION.to_s
+  sha256 SHA_256.to_s
+
+  url do
+    [
+      "#{ONIVIM_BASE_URL}/downloads/Onivim2.dmg?channel=stable&token=#{AuthenticationProvider.new.download_token}",
+      { using: OniVimDownloadStrategy, referer: "https://github.com/marblenix/homebrew-onivim2" },
+    ]
+  end
+  name "OniVim2"
+  desc "Native, lightweight modal code editor"
+  homepage ONIVIM_BASE_URL.to_s
+
+  conflicts_with cask: "onivim2-nightly"
+
+  app "OniVim2.app"
+  shim_script = "#{staged_path}/oni2.wrapper.sh"
+  binary shim_script, target: "oni2"
+
+  preflight do
+    IO.write shim_script, <<~EOS
+      #!/bin/sh
+      exec "#{appdir}/OniVim2.app/Contents/MacOS/Oni2" "$@"
+    EOS
+  end
+
+  zap trash: ZAP_LIST
 end

--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2020 marblenix
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/README.md
+++ b/README.md
@@ -3,6 +3,11 @@
 
 ![Test Install](https://github.com/marblenix/homebrew-onivim2/workflows/Test%20Install/badge.svg)
 
+## License
+Code in this repository is under the MIT License.
+
+Binary and source code for OniVim2 is under the [Outrun Labs EULA](https://github.com/onivim/oni2/blob/master/Outrun-Labs-EULA-v1.1.md).
+
 ## Prerequisites
 export HOMEBREW_ONIVIM_SERIAL="XXXXXXXX-XXXX-XXXX-XXXX-XXXXXXXXXXXX"
 


### PR DESCRIPTION
* Vastly improve `brew` commands time by delaying license check until actual install happens
* Added 'oni2' shim to start onivim from command line
* Added support for --zap on uninstall to remove all preferences

MERGE BLOCKED BY https://github.com/Homebrew/brew/pull/10548